### PR TITLE
Added Apple Silicon to build instructions

### DIFF
--- a/icon-2.0/goloop/get-started/build.md
+++ b/icon-2.0/goloop/get-started/build.md
@@ -51,6 +51,14 @@ pip install -r pyee/requirements.txt
 make
 ```
 
+**Mac M1 (Apple silicon)**
+
+```
+export ROCKSDB_PATH="$(echo) $(brew --prefix rocksdb)"
+export SNAPPY_PATH="$(echo) $(brew --prefix snappy)"
+CGO_CFLAGS=-I$ROCKSDB_PATH/include CGO_LDFLAGS="-L$ROCKSDB_PATH/lib -L$SNAPPY_PATH/lib" make
+```
+
 Output binaries are placed under `bin/` directory.
 
 ### Build python package


### PR DESCRIPTION
This pull request adds instructions to the build guide to make goloop on Apple silicon. Moved here upon request.