### PR TITLE
replace solidwallet tracker with community

### DIFF
--- a/icon-stack/icon-networks/main-network.md
+++ b/icon-stack/icon-networks/main-network.md
@@ -42,7 +42,7 @@ _Test network. First round of testing_
 
 [Debug API Endpoint](https://sejong.net.solidwallet.io/api/v3d)
 
-[Tracker](https://sejong.tracker.solidwallet.io)
+[Tracker](https://tracker.sejong.icon.community)
 
 ### How to deploy
 


### PR DESCRIPTION
This PR replaces the solidwallet sejong tracker (https://sejong.tracker.solidwallet.io) with the community one (https://tracker.sejong.icon.community/). Tracker is still getting updates but passing QC checks. 