### PR TITLE
fixed typo

### DIFF
--- a/icon-stack/client-apis/json-rpc-api/v3.md
+++ b/icon-stack/client-apis/json-rpc-api/v3.md
@@ -406,7 +406,7 @@ None
 | from        | T\_ADDR\_EOA   |     O      | Message sender's address.                   |
 | to          | T\_ADDR\_SCORE |     O      | SCORE address that will handle the message. |
 | height      | T\_INT         |     X      | Integer of a block height                   |
-| dataType    | T\_DATA\_TYPE  |     O      | `call` is the only possible data type.      |
+| dataType    | T\_DATA\_TYPE  |     O      | `icx_call` is the only possible data type.  |
 | data        | T\_DICT        |     O      | See Parameters - data.                      |
 | data.method | String         |     O      | Name of the function.                       |
 | data.params | T\_DICT        |     O      | Parameters to be passed to the function.    |


### PR DESCRIPTION
the value should be `icx_call` not just `call`. If a request is made with `dataType = call` the response will be `{"jsonrpc":"2.0","error":{"code":-32601,"message":"MethodNotFound"},"id":1}`