### PR TITLE
add link to tracker swagger docs

### DIFF
--- a/icon-stack/icon-networks/main-network.md
+++ b/icon-stack/icon-networks/main-network.md
@@ -55,3 +55,11 @@ You can get test [ICX](../../concepts/economics/icx.md) for testnets using the f
 * [https://faucet.ibriz.ai](https://faucet.ibriz.ai)
 * [https://faucet.sharpn.tech](https://faucet.sharpn.tech)
 * [https://faucet.reliantnode.com](https://faucet.reliantnode.com)
+
+### Tracker API docs
+
+To access indexed network data for each network, there are [OpenAPI / Swagger docs](https://swagger.io/specification/) for each network that feed the tracker but can also assist with building dapps and other network analytics tools. To use testnets, replace the subdomain for the tracker for the appropriate testnet. 
+
+* [Main API Docs](https://tracker.icon.community/api/v1/docs/index.html)
+* [Contracts API Docs](https://tracker.icon.community/api/v1/contracts/docs)
+* [Governance API Docs](https://tracker.icon.community/api/v1/governance/docs)


### PR DESCRIPTION
Adding link to the swagger docs that feed the tracker. Several people in the community are using these so they should be documented here as well.  