### PR TITLE
remove conflicting instruction

### DIFF
--- a/getting-started/how-to-run-a-local-network/setting-up-a-local-network.md
+++ b/getting-started/how-to-run-a-local-network/setting-up-a-local-network.md
@@ -15,6 +15,7 @@ $ git clone https://github.com/icon-project/goloop.git
 $ cd goloop
 $ make gochain-icon-image
 ```
+> A prebuilt image is also available at [iconcommunity/goloop](https://hub.docker.com/r/iconcommunity/gochain). But a couple things to consider, this image might not be the latest version of `goloop` and if you use it it will be necessary to edit the docker compose files (`.yml` files) to point to `iconcommunity/gochain` instead of `goloop/gochain-icon`.
 
 * Verify generated image
 

--- a/getting-started/how-to-run-a-local-network/setting-up-a-local-network.md
+++ b/getting-started/how-to-run-a-local-network/setting-up-a-local-network.md
@@ -14,8 +14,6 @@ description: Steps to setup a local network
 $ git clone https://github.com/icon-project/goloop.git
 $ cd goloop
 $ make gochain-icon-image
-# You can also use the prebuild image https://hub.docker.com/r/iconcommunity/gochain
-# if you can't get the image to build locally
 ```
 
 * Verify generated image


### PR DESCRIPTION
if the user pulls the docker image from the `iconcommunity/goloop` repo the rest of the instructions will fail because all the scripts and compose.yml file are referencing the image called `goloop/gochain-icon`